### PR TITLE
fix windows aws ssl cert verification

### DIFF
--- a/lib/sensu/transport/snssqs.rb
+++ b/lib/sensu/transport/snssqs.rb
@@ -34,6 +34,8 @@ module Sensu
         @connected = true
         @results_callback = proc {}
         @keepalives_callback = proc {}
+        # Sensu Windows install does not include a valid cert bundle for AWS
+        Aws.use_bundled_cert! if Gem.win_platform?
         @sqs = Aws::SQS::Client.new(region: @settings[:region])
         @sns = Aws::SNS::Client.new(region: @settings[:region])
 


### PR DESCRIPTION
The sensu ruby install on Windows doesn't include the proper certs (or
if it does they're not loaded properly) to connect to AWS.
`@sns.publish` generates an error like:

```
C:/opt/sensu/embedded/lib/ruby/2.0.0/net/http.rb:921:in `connect': SSL_connect returned=1 errno=0 state=error: certificate verify failed (Seahorse::Client::NetworkingError)
```

Using the cert bundle included with the aws-sdk-core gem should work
around this.

Sourced from https://github.com/aws/aws-sdk-core-ruby/issues/166#issuecomment-111603660
