### PR TITLE
Treat fanout (client) subscriptions as a no-op

### DIFF
--- a/lib/sensu/transport/snssqs.rb
+++ b/lib/sensu/transport/snssqs.rb
@@ -65,6 +65,10 @@ module Sensu
 
       # subscribe will begin "subscribing" to the consuming sqs queue.
       #
+      # This method is intended for use by the Sensu server; fanout
+      # subscriptions initiated by the Sensu client process are
+      # treated as a no-op.
+      #
       # What this really means is that we will start polling for
       # messages from the SQS queue, and, depending on the message
       # type, it will call the appropriate callback.
@@ -77,6 +81,11 @@ module Sensu
       #
       # "funnel" and "type" parameters are completely ignored.
       def subscribe(type, pipe, funnel = nil, options = {}, &callback)
+        if type == :fanout
+          self.logger.debug("skipping unsupported fanout subscription type=#{type}, pipe=#{pipe}, funnel=#{funnel}")
+          return
+        end
+
         self.logger.info("subscribing to type=#{type}, pipe=#{pipe}, funnel=#{funnel}")
 
         if pipe == KEEPALIVES_STR


### PR DESCRIPTION
As documented in [issue #5](https://github.com/SimpleFinance/sensu-transport-snssqs/issues/5), clients with subscriptions defined encounter
exceptions when they attempt to process check results as check requests.

With Sensu's forthcoming [native silencing implementation](https://github.com/sensu/sensu/issues/1328), each client
definition will include a subscription for "client:$CLIENT_NAME". For the
purposes of this silencing implemetation, it's not important that the client
consume check requests from this subscription, but it is important that the
subscription is present in the client definition sent via keepalive messages.

When Sensu processes call `subscribe()` on the transport object, they pass a
queue type. Sensu server processes subscribe with type `:direct` while
Sensu client processes use type `:fanout`. This distinction makes it possible
for us to treat client subscriptions for this transport as a no-op.
